### PR TITLE
Error fixes

### DIFF
--- a/projects/sd-img-annotator/src/lib/directives/sd-img-annotator.directive.ts
+++ b/projects/sd-img-annotator/src/lib/directives/sd-img-annotator.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, Output, EventEmitter, NgZone, HostBinding, ElementRef } from '@angular/core';
+import { Directive, Input, Output, EventEmitter, NgZone, ElementRef } from '@angular/core';
 
 // @ts-ignore
 import * as OSDAnnotorious from '@recogito/annotorious-openseadragon';

--- a/projects/sd-img-annotator/src/lib/directives/sd-img-annotator.directive.ts
+++ b/projects/sd-img-annotator/src/lib/directives/sd-img-annotator.directive.ts
@@ -141,7 +141,6 @@ export class SdImgAnnotatorDirective {
     //   http://openseadragon.github.io/examples/tilesource-image/
     // we also have better running outside Angular zone:
     //   http://openseadragon.github.io/docs/
-		
     const viewer = this._ngZone.runOutsideAngular(() => {
       return new Viewer({
         id: 'osd',

--- a/projects/sd-img-annotator/src/lib/directives/sd-img-annotator.directive.ts
+++ b/projects/sd-img-annotator/src/lib/directives/sd-img-annotator.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, Output, EventEmitter, NgZone, HostBinding } from '@angular/core';
+import { Directive, Input, Output, EventEmitter, NgZone, HostBinding, ElementRef } from '@angular/core';
 
 // @ts-ignore
 import * as OSDAnnotorious from '@recogito/annotorious-openseadragon';
@@ -64,8 +64,6 @@ export class SdImgAnnotatorDirective {
   @Input()
   public source: string;
 
-	@HostBinding('id')
-	private readonly id = "osd";
   /**
    * The initial configuration for the annotator. Note that the image property
    * will be overridden with the img being decorated by this directive.
@@ -125,7 +123,7 @@ export class SdImgAnnotatorDirective {
   @Output()
   public mouseLeaveAnnotation: EventEmitter<AnnotationEvent>;
 
-  constructor(private _ngZone: NgZone) {
+  constructor(private _ngZone: NgZone, private el: ElementRef) {
     this._tool = 'rect';
     this.source = '';
     this.createAnnotation = new EventEmitter<AnnotationEvent>();
@@ -143,10 +141,11 @@ export class SdImgAnnotatorDirective {
     //   http://openseadragon.github.io/docs/
     const viewer = this._ngZone.runOutsideAngular(() => {
       return new Viewer({
-        id: 'osd',
+				element: this.el.nativeElement,
         tileSources: {
           type: 'image',
-          url: this.source,
+          //url: this.source,
+					url: 'http://dl.fujifilm-x.com/global/products/cameras/gfx100s/sample-images/gfx100s_sample_04_oulq.jpg'
         },
         prefixUrl: 'http://openseadragon.github.io/openseadragon/images/',
       });

--- a/projects/sd-img-annotator/src/lib/directives/sd-img-annotator.directive.ts
+++ b/projects/sd-img-annotator/src/lib/directives/sd-img-annotator.directive.ts
@@ -144,8 +144,7 @@ export class SdImgAnnotatorDirective {
 				element: this.el.nativeElement,
         tileSources: {
           type: 'image',
-          //url: this.source,
-					url: 'http://dl.fujifilm-x.com/global/products/cameras/gfx100s/sample-images/gfx100s_sample_04_oulq.jpg'
+          url: this.source
         },
         prefixUrl: 'http://openseadragon.github.io/openseadragon/images/',
       });

--- a/projects/sd-img-annotator/src/lib/directives/sd-img-annotator.directive.ts
+++ b/projects/sd-img-annotator/src/lib/directives/sd-img-annotator.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, Output, EventEmitter, NgZone } from '@angular/core';
+import { Directive, Input, Output, EventEmitter, NgZone, HostBinding } from '@angular/core';
 
 // @ts-ignore
 import * as OSDAnnotorious from '@recogito/annotorious-openseadragon';
@@ -64,6 +64,8 @@ export class SdImgAnnotatorDirective {
   @Input()
   public source: string;
 
+	@HostBinding('id')
+	private readonly id = "osd";
   /**
    * The initial configuration for the annotator. Note that the image property
    * will be overridden with the img being decorated by this directive.
@@ -139,6 +141,7 @@ export class SdImgAnnotatorDirective {
     //   http://openseadragon.github.io/examples/tilesource-image/
     // we also have better running outside Angular zone:
     //   http://openseadragon.github.io/docs/
+		
     const viewer = this._ngZone.runOutsideAngular(() => {
       return new Viewer({
         id: 'osd',
@@ -151,7 +154,7 @@ export class SdImgAnnotatorDirective {
     });
 
     // this._ann = new Annotorious(viewer, cfg);
-    this._ann = new OSDAnnotorious(viewer, cfg);
+    this._ann = OSDAnnotorious(viewer, cfg);
 
     // initial annotations
     if (this.annotations?.length) {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,2 @@
 <h1>Annotorious OpenSeadragon</h1>
-<div [style.minHeight.px]="500" annoSdImgAnnotator source="/assets/sample.jpg"></div>
+<div annoSdImgAnnotator source="/assets/sample.jpg"></div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,2 @@
 <h1>Annotorious OpenSeadragon</h1>
-<div id="osd" annoSdImgAnnotator source="/assets/sample.jpg"></div>
+<div [style.minHeight.px]="500" annoSdImgAnnotator source="/assets/sample.jpg"></div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,3 +3,7 @@ body {
   color: white;
   background-color: #202020;
 }
+
+.openseadragon-container {
+	min-height: 500px;
+}


### PR DESCRIPTION
The main piece that fixed your problem was removing the 'new' from the `OSDAnnotorious` call.
```
    this._ann = OSDAnnotorious(viewer, cfg);
```
instead of 
```
    this._ann = new OSDAnnotorious(viewer, cfg);
```

I added a placeholder style to your css to get the viewer to show up.  It was initially rendering with a 0 height.  This prevented the 'cacheKey' error from presenting on initial load, but will still pop up after zooming a bit on the image.  I honestly am not sure what's throwing that error, though everything seems to be working fine even with it there.

I also found that that 'cacheKey' error does not come up when viewing other images.  I tested with [this one](http://dl.fujifilm-x.com/global/products/cameras/gfx100s/sample-images/gfx100s_sample_04_oulq.jpg)

I also removed the 'osd' id from the app.component and set up OSD to use the nativeElement from the directive, so you won't have to rely on the end user adding the correct id.  Hope that's alright :)